### PR TITLE
Site footer correction

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ nav:
     - Contributing: contributing.md
 
 
-copyright: GA4GH Genomic Knowledge Standards Workstream, Seqcol team
+copyright: GA4GH Large Scale Genomics Workstream, Seqcol team
 home_link: null
 navbar:
   left:


### PR DESCRIPTION
Currently the SeqCol specs have `GA4GH Genomic Knowledge Standards Workstream, Seqcol team` on every page footer, I'm assuming that is taken from the copyright string in this file. Per guidance from @andrewyatz, updating to reflect that this is a product of the LSG Work Stream.