### PR TITLE
Update service info description for refget.sequence and refget.secol

### DIFF
--- a/docs/seqcol.md
+++ b/docs/seqcol.md
@@ -394,7 +394,7 @@ ga4gh:
   "name": "Sequence Collection server",
   "type": {
     "group": "org.ga4gh",
-    "artifact": "refget.seqcol",
+    "artifact": "refget-seqcol",
     "version": "1.0.0"
   },
   "description": "Collection of sequences from digests.",

--- a/docs/seqcol.md
+++ b/docs/seqcol.md
@@ -351,6 +351,7 @@ Under these umbrella endpoints are a few more specific sub-endpoints, described 
 - *Return value*: Must include the Seqcol JSON Schema that is used by this server
 
 The `/service-info` endpoint should follow the [GA4GH-wide specification for service info](https://github.com/ga4gh-discovery/ga4gh-service-info/) for general description of the service.
+The `artifact` describing sequence collection entities should be `refget.seqcol`. See example below. 
 Then, it should also add a few specific pieces of information under a `seqcol` property:
 
  - `schema`: MUST return the JSON Schema implemented by the server.
@@ -385,6 +386,58 @@ ga4gh:
     - sequences
 ```
 
+##### Example of a service-info response
+
+```json
+{
+  "id": "org.ga4gh.refget.seqcol",
+  "name": "Sequence Collection server",
+  "type": {
+    "group": "org.ga4gh",
+    "artifact": "refget.seqcol",
+    "version": "1.0.0"
+  },
+  "description": "Collection of sequences from digests.",
+  "organization": {
+    "name": "My organization",
+    "url": "https://example.com"
+  },
+  "contactUrl": "mailto:support@example.com",
+  "documentationUrl": "https://docs.myservice.example.com",
+  "createdAt": "2024-01-01T11:00:00Z",
+  "updatedAt": "2024-01-01T11:00:00Z",
+  "environment": "prod",
+  "version": "1.4.1",
+  "seqcol": {
+    "schema": {
+      "description": "A collection of biological sequences.",
+      "type": "object",
+      "$id": "https://example.com/sequence_collection",
+      "properties": {
+        "lengths": {
+          "$ref": "/lengths"
+        },
+        "names": {
+          "$ref": "/names"
+        },
+        "sequences": {
+          "$ref": "/sequences"
+        }
+      },
+      "required": [ 
+        "names", 
+        "sequences" 
+      ],
+      "ga4gh": {
+        "inherent": [
+          "names",
+          "sequences"
+        ]
+      }
+    }
+  }
+}
+```
 
 #### 3.2 Collection
 

--- a/docs/sequences.md
+++ b/docs/sequences.md
@@ -381,7 +381,7 @@ GET /service-info
   "name": "Refget server",
   "type": {
     "group": "org.ga4gh",
-    "artifact": "refget.sequence",
+    "artifact": "refget-sequence",
     "version": "2.0.0"
   },
   "description": "Reference sequences from checksums",

--- a/docs/sequences.md
+++ b/docs/sequences.md
@@ -381,7 +381,7 @@ GET /service-info
   "name": "Refget server",
   "type": {
     "group": "org.ga4gh",
-    "artifact": "refget",
+    "artifact": "refget.sequence",
     "version": "2.0.0"
   },
   "description": "Reference sequences from checksums",


### PR DESCRIPTION
This PR clarifies the artifacts used to describe `refget.sequence` and `refget.seqcol` and add a concrete example of what the service info payload should look like for a sequence collection server